### PR TITLE
Docker Image and GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+outcomes
+.git

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,52 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: [3.7]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install -r requirements.txt
+        pip list
+    - name: Check for vulnerabilities in libraries
+      run: |
+        pip install safety
+        pip freeze | safety check
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Extract tag name
+      shell: bash
+      run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+      id: extract_tag_name
+
+    - name: Build Covid19-Mesa Image
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: ncsa/covid19-mesa:${{ steps.extract_tag_name.outputs.imagetag }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tag: "${GITHUB_REF##*/}"
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__
 *.png
 *.csv
+.idea
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.6-buster
+
+WORKDIR /opt/covid19-mesa
+COPY requirements.txt .
+
+RUN pip install parsl==0.9.0;pip install --force-reinstall "funcx>=0.0.2a0"
+RUN pip install -r requirements.txt
+COPY ./ .

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ networkx==2.4
 numpy==1.18.2
 pandas==1.0.3
 pathos==0.2.5
-pkg-resources==0.0.0
 pox==0.2.7
 poyo==0.5.0
 ppft==1.6.6.1


### PR DESCRIPTION
# Problem
FuncX endpoint requires a docker image with all of the dependencies in order to execute the Covid model. 

# Approach
Add a docker file that builds an image that contains all of the dependent modules, the Covid19-Mesa model code, as well as funcX worker dependencies.

Add GitHub action to do some very crude validation of the code and then builds a docker image tagged with the branch.

