### PR TITLE
perf: Use Python builtin random.random to generate Poisson samples

### DIFF
--- a/covidmodel.py
+++ b/covidmodel.py
@@ -4,6 +4,7 @@
 # {nunezco,jake}@illinois.edu
 
 # A simple tunable model for COVID-19 response
+import math
 from operator import mod
 from sqlite3 import DatabaseError
 import timeit
@@ -35,6 +36,17 @@ def bernoulli_rvs(p):
     if r >= p:
         return 1
     return 0
+
+
+def poisson_rvs(mu):
+    p0 = math.exp(-mu)
+    F = p0
+    i = 0
+    sample = random.random()
+    while sample >= F:
+        i += 1
+        F += p0 * (mu ** i) / math.factorial(i)
+    return i
 
 
 class Stage(Enum):
@@ -732,7 +744,7 @@ class CovidAgent(Agent):
             new_position = self.random.choice(possible_steps)
 
             self.model.grid.move_agent(self, new_position)
-            self.agent_data.curr_dwelling = poisson.rvs(self.model.model_data.avg_dwell)
+            self.agent_data.curr_dwelling = poisson_rvs(self.model.model_data.avg_dwell)
 
 
 ########################################
@@ -1560,7 +1572,7 @@ class CovidModel(Model):
                     arange = 0
 
                     while not(in_range):
-                        arange = poisson.rvs(self.model_data.new_agent_age_mean)
+                        arange = poisson_rvs(self.model_data.new_agent_age_mean)
                         if arange in range(0, 9):
                             in_range = True
                     


### PR DESCRIPTION
I'm not sure of the typical values for the input to `poisson_rvs`.
There are 2 possible followup improvements:
1. For large mu, you can use the method described in https://stackoverflow.com/questions/69596814/improved-inverse-transform-method-for-poisson-random-variable-generation-in-r
2. The `poisson_rvs` could be defined in Cython instead.

Benchmark code:
```python
import time
import random
import math

from scipy.stats import poisson

mean = 7.5

def poisson_rvs(mu):
    p0 = math.exp(-mu)
    F = p0
    i = 0
    sample = random.random()
    while sample >= F:
        i += 1
        F += p0 * (mu ** i) / math.factorial(i)
    return i


scipy_list = []
tic = time.time()
for i in range(1000):
    scipy_list.append(poisson.rvs(mean))
elapsed = time.time() - tic
print("scipy.stats", elapsed, sum(scipy_list) / len(scipy_list))
custom_list = []
tic = time.time()
for i in range(1000):
    custom_list.append(poisson_rvs(mean))
elapsed_custom = time.time() - tic
print("Custom", elapsed_custom, sum(custom_list) / len(custom_list))
print("Speedup", round(elapsed / elapsed_custom, 4))
```

```
scipy.stats 0.1656346321105957 7.525
Custom 0.008195161819458008 7.561
Speedup 20.2113
```